### PR TITLE
Support OpenSSL 1.1

### DIFF
--- a/utils/hashutil.cc
+++ b/utils/hashutil.cc
@@ -685,31 +685,31 @@ namespace fawn {
 
     std::string HashUtil::MD5Hash(const char* inbuf, size_t in_length)
     {
-	EVP_MD_CTX mdctx;
+        std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> mdctx(EVP_MD_CTX_new(),
+                                                        EVP_MD_CTX_free);
         unsigned char md_value[EVP_MAX_MD_SIZE];
         unsigned int md_len;
 
-	EVP_DigestInit(&mdctx, EVP_md5());
-	EVP_DigestUpdate(&mdctx, (const void*) inbuf, in_length);
-	EVP_DigestFinal_ex(&mdctx, md_value, &md_len);
-	EVP_MD_CTX_cleanup(&mdctx);
+        EVP_DigestInit(mdctx.get(), EVP_md5());
+        EVP_DigestUpdate(mdctx.get(), (const void*) inbuf, in_length);
+        EVP_DigestFinal_ex(mdctx.get(), md_value, &md_len);
 
-	return string((char*)md_value, (size_t)md_len);
+        return string((char*)md_value, (size_t)md_len);
     }
 
 
     std::string HashUtil::SHA1Hash(const char* inbuf, size_t in_length)
     {
-	EVP_MD_CTX mdctx;
-	string ret;
+        std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> mdctx(EVP_MD_CTX_new(),
+                                                        EVP_MD_CTX_free);
+        string ret;
         unsigned char md_value[EVP_MAX_MD_SIZE];
         unsigned int md_len;
 
-	EVP_DigestInit(&mdctx, EVP_sha1());
-	EVP_DigestUpdate(&mdctx, (const void*) inbuf, in_length);
-	EVP_DigestFinal_ex(&mdctx, md_value, &md_len);
-	EVP_MD_CTX_cleanup(&mdctx);
+        EVP_DigestInit(mdctx.get(), EVP_sha1());
+        EVP_DigestUpdate(mdctx.get(), (const void*) inbuf, in_length);
+        EVP_DigestFinal_ex(mdctx.get(), md_value, &md_len);
 
-	return string((char*)md_value, (size_t)md_len);
+        return string((char*)md_value, (size_t)md_len);
     }
 } // namespace fawn

--- a/utils/hashutil.h
+++ b/utils/hashutil.h
@@ -2,6 +2,7 @@
 #ifndef _HASHUTIL_H_
 #define _HASHUTIL_H_
 
+#include <memory>
 #include <sys/types.h>
 #include <string>
 #include <stdlib.h>


### PR DESCRIPTION
The structs are no longer available in modern OpenSSL versions.
OpenSSL 1.1 was released in 2016, so most users have probably upgraded
by now and will run into build issues.