### PR TITLE
Replace no longer existing tbb::atomic with std::atomic

### DIFF
--- a/fawnds/bdb.h
+++ b/fawnds/bdb.h
@@ -4,10 +4,11 @@
 
 #include "fawnds.h"
 #include "config.h"
-#include <tbb/atomic.h>
+#include <atomic>
 
 #ifdef HAVE_LIBDB
 #include <db.h>
+#include <atomic>
 
 namespace fawn {
 
@@ -66,7 +67,7 @@ namespace fawn {
         size_t key_len_;
         size_t data_len_;
 
-        tbb::atomic<size_t> size_;
+        std::atomic<size_t> size_;
 
         friend struct IteratorElem;
     };

--- a/fawnds/fawnds_combi.cc
+++ b/fawnds/fawnds_combi.cc
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <sstream>
 #include <time.h>
+#include <atomic>
 
 namespace fawn {
 

--- a/fawnds/fawnds_combi.h
+++ b/fawnds/fawnds_combi.h
@@ -122,8 +122,8 @@ namespace fawn {
 
         size_t back_store_size_;
 
-        tbb::atomic<bool> convert_task_running_;    // also protected by mutex_
-        tbb::atomic<bool> merge_task_running_;      // also protected by mutex_
+        std::atomic<bool> convert_task_running_;    // also protected by mutex_
+        std::atomic<bool> merge_task_running_;      // also protected by mutex_
 
         friend class MergeTask;
 
@@ -131,8 +131,8 @@ namespace fawn {
         static TaskScheduler task_scheduler_merge_;
 
         static const size_t latency_track_store_count_ = 100;
-        mutable tbb::atomic<uint64_t> latencies_[4][latency_track_store_count_];
-        mutable tbb::atomic<uint64_t> counts_[4][latency_track_store_count_];
+        mutable std::atomic<uint64_t> latencies_[4][latency_track_store_count_];
+        mutable std::atomic<uint64_t> counts_[4][latency_track_store_count_];
     };
 
 } // namespace fawn

--- a/fawnds/fawnds_monitor.h
+++ b/fawnds/fawnds_monitor.h
@@ -5,7 +5,8 @@
 #include "fawnds_proxy.h"
 #include "rate_limiter.h"
 #include <pthread.h>
-#include <tbb/atomic.h>
+#include <atomic>
+#include <unistd.h>
 
 namespace fawn {
 
@@ -40,8 +41,8 @@ namespace fawn {
 
         volatile bool exiting_;
 
-        mutable tbb::atomic<size_t> write_ops_;
-        mutable tbb::atomic<size_t> read_ops_;
+        mutable std::atomic<size_t> write_ops_;
+        mutable std::atomic<size_t> read_ops_;
 
         uint64_t last_time_;
 

--- a/fawnds/file_store.cc
+++ b/fawnds/file_store.cc
@@ -125,9 +125,9 @@ namespace fawn {
 
         // TODO: concurrent operations
 
-        file_store->next_append_id_ = next_append_id_;
+        file_store->next_append_id_.exchange(next_append_id_);
         file_store->end_id_ = end_id_;
-        file_store->next_sync_ = next_sync_;
+        file_store->next_sync_.exchange(next_sync_);
 
         return OK;
     }

--- a/fawnds/file_store.h
+++ b/fawnds/file_store.h
@@ -5,7 +5,7 @@
 #include "fawnds.h"
 #include "file_io.h"    // for iovec
 #include "task.h"
-#include <tbb/atomic.h>
+#include <atomic>
 #include <tbb/queuing_mutex.h>
 #include <tbb/queuing_rw_mutex.h>
 #include <boost/dynamic_bitset.hpp>
@@ -82,9 +82,9 @@ namespace fawn {
     private:
         size_t data_len_;
 
-        tbb::atomic<off_t> next_append_id_;
+        std::atomic<off_t> next_append_id_;
         off_t end_id_;
-        tbb::atomic<off_t> next_sync_;
+        std::atomic<off_t> next_sync_;
 
         bool use_buffered_io_only_;
 
@@ -110,8 +110,8 @@ namespace fawn {
         };
         mutable tbb::queuing_rw_mutex cache_mutex_;
         mutable cache_entry cache_[cache_size_];
-        mutable tbb::atomic<size_t> cache_hit_;
-        mutable tbb::atomic<size_t> cache_miss_;
+        mutable std::atomic<size_t> cache_hit_;
+        mutable std::atomic<size_t> cache_miss_;
 
         class SyncTask : public Task {
         public:

--- a/fawnds/global_limits.h
+++ b/fawnds/global_limits.h
@@ -3,7 +3,7 @@
 #define _GLOBAL_LIMITS_H_
 
 #include "rate_limiter.h"
-#include <tbb/atomic.h>
+#include <atomic>
 
 namespace fawn {
 
@@ -29,7 +29,7 @@ namespace fawn {
     private:
         static GlobalLimits global_limits_;
 
-        tbb::atomic<int> disabled_;
+        std::atomic<int> disabled_;
 
         RateLimiter convert_rate_limiter_;
         RateLimiter merge_rate_limiter_;

--- a/fawnds/rate_limiter.h
+++ b/fawnds/rate_limiter.h
@@ -2,7 +2,7 @@
 #ifndef _RATE_LIMITER_H_
 #define _RATE_LIMITER_H_
 
-#include <tbb/atomic.h>
+#include <atomic>
 
 namespace fawn {
 
@@ -38,13 +38,13 @@ namespace fawn {
         void update_tokens();
 
     private:
-        tbb::atomic<int64_t> tokens_;
+        std::atomic<int64_t> tokens_;
         int64_t max_tokens_;
         int64_t new_tokens_per_interval_;
         int64_t ns_per_interval_;
         int64_t min_retry_interval_ns_;
 
-        tbb::atomic<int64_t> last_time_;
+        std::atomic<int64_t> last_time_;
     };
 
 } // namespace fawn

--- a/fawnds/task.cc
+++ b/fawnds/task.cc
@@ -9,7 +9,8 @@
 #ifdef __linux__
 
 #include <sys/types.h>
-#include <bits/syscall.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 extern "C" {
 pid_t gettid()


### PR DESCRIPTION
tbb::atomic no longer exists in recent tbb versions

See: https://community.intel.com/t5/Intel-oneAPI-Threading-Building/Deprecated-features-in-OneAPI-TBB-runtime-loader-task-scheduler/m-p/1247466